### PR TITLE
feat(macos): add herdr to AI Tools category

### DIFF
--- a/macOS/manifests/categories/07-ai-tools.Brewfile
+++ b/macOS/manifests/categories/07-ai-tools.Brewfile
@@ -1,4 +1,5 @@
 brew "gemini-cli"
+brew "herdr"
 
 cask "chatgpt"
 cask "claude"


### PR DESCRIPTION
## Summary
- `macOS/manifests/categories/07-ai-tools.Brewfile`에 `brew "herdr"` 추가
- herdr는 coding agent 멀티플렉서(homebrew-core formula, stable 0.7.4, bottled)로, 단일 터미널에서 여러 coding agent를 관리
- `ai_tools` 카테고리는 `standard` / `full` 프로필 모두에 포함되므로 두 프로필에서 자동 설치됨

## Verification
- `brew bundle list --file macOS/manifests/categories/07-ai-tools.Brewfile` → `herdr` 파싱 확인
- `brew info herdr` → homebrew-core에 존재함을 확인 (stable 0.7.4)

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)

## Summary by Sourcery

New Features:
- Include the herdr formula in the macOS AI Tools Brewfile for automatic installation across relevant profiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Herdr AI tool to the macOS Homebrew installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->